### PR TITLE
header & button-black

### DIFF
--- a/public/hackathon-2019.html
+++ b/public/hackathon-2019.html
@@ -15,14 +15,17 @@
   <title>CodeWuxi Hackathon 2019</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.3.1/dist/css/bootstrap.min.css">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat|Comfortaa">
-  <link rel="stylesheet" href="//at.alicdn.com/t/font_1086808_a5k287cz7sf.css">
+  <link rel="stylesheet" href="//at.alicdn.com/t/font_1086808_cspu73qdny5.css">
   <script src="https://unpkg.com/scrollreveal@4.0.0/dist/scrollreveal.min.js"></script>
 
 </head>
 
 <body>
   <header>
-    <!-- <i class="iconfont icon-codewuxi"></i> -->
+    <i class="iconfont icon-codewuxi"></i>
+    <div class="header-right">
+      <i class="iconfont icon-menu"></i>
+    </div>
   </header>
 
   <div class="hack-2019-wrapper">
@@ -637,6 +640,17 @@
               </h3>
               <div>
                 <p>hackathon@codewuxi.com</p>
+              </div>
+              <div class="button-group">
+                <button class="cw-button button-black show-map-button">
+                  参赛者报名
+                </button>
+                <button class="cw-button button-black show-road-button">
+                  志愿者报名
+                </button>
+                <button class="cw-button button-black show-road-button">
+                  合作伙伴招募
+                </button>
               </div>
             </section>
           </div>

--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -53,9 +53,11 @@ header {
   left: 0;
   padding: 0 1rem;
   width: 100vw;
-  display: flex;
-  align-items: center;
   height: .8rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #fff;
   z-index: 99;
 
   .container .row .col-xl-1 {
@@ -92,6 +94,15 @@ footer {
 
   .contact-wrapper, .container {
     z-index: 1;
+  }
+
+  .contact-wrapper {
+    .section-content {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+    }
   }
 
   .footer-logo-wrapper {
@@ -176,10 +187,10 @@ footer {
 }
 
 .button-group {
+  margin-top: .1rem;
+  width: 80%;
   display: flex;
-  .cw-button:first-child {
-    margin-right: .8rem;
-  }
+  justify-content: space-between;
 }
 
 .cw-button {
@@ -188,13 +199,24 @@ footer {
   font-size: .24rem;
   letter-spacing: .03rem;
   font-weight: 200;
-  border: 1px solid $--color-black;
-  background-color: $--color-white;
+  border: 1px solid #000;
+  background-color: #fff;
   outline: none;
   transition: all .5s;
+
+  &.button-black {
+    width: 2rem;
+    border: 1px solid #fff;
+    background-color: #000;
+    color: #fff;
+    &:hover {
+      color: #000;
+      background-color: #fff;
+    }
+  }
   &:hover {
-    color: $--color-white;
-    background-color: $--color-black;
+    color: #fff;
+    background-color: #000;
   }
 }
 
@@ -265,13 +287,14 @@ footer {
   .cw-dialog {
     .dialog-content {
       width: 100%;
-      height: 70vh;
+      height: 80vh;
       top: auto;
       left: 0;
       bottom: 0;
       transform: none;
       .icon-close {
-        font-size: 32px;
+        bottom: 1rem;
+        font-size: 38px;
       }
     }
   }

--- a/src/css/hackathon-2019.scss
+++ b/src/css/hackathon-2019.scss
@@ -5,8 +5,11 @@
   height: 100%;
 }
 
-.hack-2019-wrapper {
+header {
+  display: none;
+}
 
+.hack-2019-wrapper {
   .banner-black {
     position: fixed;
     top: 0;
@@ -255,6 +258,10 @@
       border-top: 1px solid #000;
       font-size: .21rem;
     }
+
+    .button-group {
+      width: 40%;
+    }
   }
 
   .awards-wrapper {
@@ -455,6 +462,9 @@ footer {
 
 // Extra small devices (portrait phones, less than 576px)
 @media (max-width: 575.98px) {
+  header {
+    display: flex;
+  }
   .hack-2019-wrapper {
     .section-wrapper {
       .section-content {
@@ -550,6 +560,9 @@ footer {
         border-top: 1px solid #000;
         font-size: .25rem;
       }
+      .button-group {
+        width: 60%;
+      }
     }
 
     .awards-wrapper {
@@ -560,6 +573,29 @@ footer {
         .award-item {
           margin-bottom: .4rem;
           width: 80%;
+          &:last-child {
+            margin-bottom: 0;
+          }
+        }
+      }
+      .other-award-list {
+        flex-direction: column;
+        flex-wrap: wrap;
+        align-items: center;
+        .other-award-item {
+          margin-top: .4rem;
+          width: 68%;
+          .other-award-rank {
+            h4 {
+              padding: .2rem .3rem;
+              font-size: .26rem;
+            }
+          }
+          p {
+            font-size: 0.2rem;
+            font-weight: 200;
+            white-space: nowrap;
+          }
         }
       }
     }


### PR DESCRIPTION
Hackathon-2019.html 页面
移动端：
1. 增加头部，左侧显示logo，右侧显示汉堡（三横）图标用于导航和立即报名按钮
2. popup框高度占屏高的80%，同时，将下部的关闭按钮适当调大并向上调整，避免safari触发下部工具栏问题
3. 奖项全部一行一个

联系我们下方增加三个按钮，分别为“参赛者报名”，“志愿者报名”和“合作伙伴招募”，具体链接后续增加